### PR TITLE
Render timeline playhead with CSS element

### DIFF
--- a/script.js
+++ b/script.js
@@ -1093,9 +1093,7 @@ document.addEventListener("DOMContentLoaded", () => {
     timelineCtx.clearRect(0, 0, width, height);
     if (!timelineEnabled || isNaN(video.duration) || video.duration === 0)
       return;
-    const x = (video.currentTime / video.duration) * width;
-    timelineCtx.fillStyle = "red";
-    timelineCtx.fillRect(x - 2, 0, 4, height);
+    // The red playhead is now rendered via the CSS #playhead element.
   }
 
   window.addEventListener("resize", resizeWaveformCanvas);

--- a/styles.css
+++ b/styles.css
@@ -1445,7 +1445,7 @@ body.modal-open * {
   padding: 0;
   top: 0;
   height: 100px;
-  overflow: hidden;
+  overflow: visible;
 
   user-select: none;
   box-sizing: border-box;
@@ -1468,9 +1468,9 @@ body.modal-open * {
 
 #playhead {
   position: absolute;
-  top: 0px;
+  top: -32px;
   width: 4px;
-  height: 100%;
+  height: calc(100% + 32px);
   background-color: rgba(255, 0, 0, 0.8);
   pointer-events: none;
   display: none;


### PR DESCRIPTION
## Summary
- Display timeline playhead using CSS #playhead element instead of canvas drawing
- Allow playhead to extend into timeline by adjusting styles and overflow
- Remove canvas-drawn playhead from timeline rendering code

## Testing
- `npm test` *(fails: enoent, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bfbfed59c8332855d508dcc12da0f