### PR TITLE
Move playhead element to timeline container

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,12 +95,12 @@
           style="position: relative; width: 100%; height: 28px"
         >
           <canvas id="timelineCanvas"></canvas>
+          <div id="playhead"></div>
           <div id="zoomHighlight"></div>
         </div>
 
         <div id="waveformContainer">
           <canvas id="waveformCanvas"></canvas>
-          <div id="playhead"></div>
         </div>
       </div>
       <input

--- a/styles.css
+++ b/styles.css
@@ -1468,12 +1468,13 @@ body.modal-open * {
 
 #playhead {
   position: absolute;
-  top: -32px;
+  top: 0;
   width: 4px;
-  height: calc(100% + 32px);
+  height: calc(100% + 104px);
   background-color: rgba(255, 0, 0, 0.8);
   pointer-events: none;
   display: none;
+  z-index: 3;
 }
 
 #samiOverlay {


### PR DESCRIPTION
## Summary
- Move playhead markup from waveform container into timeline container for CSS-based rendering
- Adjust playhead CSS to align with new container and stay above zoom highlight

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c165797c48332953c0aaeac46ea1b