### PR TITLE
Fix playhead alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -2209,7 +2209,7 @@ ${styleLines}
       updateZoomHighlight();
 
       const phW = playheadDiv.offsetWidth;
-      const visW = waveformContainer.clientWidth;
+      const visW = timelineContainer.clientWidth;
 
       let relX;
       if (segmentLength >= totalSamples) {
@@ -2691,19 +2691,15 @@ ${styleLines}
       }
     }
 
-    const visibleWidth = waveformCanvas.getBoundingClientRect().width;
-    const playheadWidth = playheadDiv.clientWidth;
-
-    const rect = waveformCanvas.getBoundingClientRect();
-    const visibleW = rect.width;
+    const timelineW = timelineContainer.getBoundingClientRect().width;
     const internalW = waveformCanvas.width;
-    const scaleFactor = visibleW / internalW;
+    const scaleFactor = timelineW / internalW;
 
-    const cssX = xPos * scaleFactor;
+    let cssX = xPos * scaleFactor;
 
     const phW = playheadDiv.offsetWidth;
 
-    cssX = Math.max(0, Math.min(visibleW - phW, cssX));
+    cssX = Math.max(0, Math.min(timelineW - phW, cssX));
     playheadDiv.style.left = cssX + "px";
 
     playheadReqId = requestAnimationFrame(updatePlayhead);
@@ -2814,7 +2810,7 @@ ${styleLines}
     updateZoomHighlight();
 
     const phW = playheadDiv.offsetWidth;
-    const visW = waveformContainer.clientWidth;
+    const visW = timelineContainer.clientWidth;
     const relX = (targetSample - panOffset) / segmentLength;
 
     let cssX = relX * visW - phW / 2;
@@ -2833,7 +2829,7 @@ ${styleLines}
     e.preventDefault();
 
     const totalSamples = audioBuffer.length;
-    const width = waveformCanvas.width;
+    const width = timelineContainer.clientWidth;
 
     const playheadStyleLeft = parseFloat(playheadDiv.style.left) || 0;
     const headRatio = playheadStyleLeft / width;


### PR DESCRIPTION
## Summary
- compute playhead position using `timelineContainer` width to keep waveform and timeline playheads aligned
- adjust zoom calculations to respect new width reference

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c184006348332a754b7e78b3d0744