### PR TITLE
Remove timeline container and related code

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,15 +90,6 @@
           />
         </div>
 
-        <div
-          id="timelineContainer"
-          style="position: relative; width: 100%; height: 28px"
-        >
-          <canvas id="timelineCanvas"></canvas>
-          <div id="playhead"></div>
-          <div id="zoomHighlight"></div>
-        </div>
-
         <div id="waveformContainer">
           <canvas id="waveformCanvas"></canvas>
         </div>

--- a/script.js
+++ b/script.js
@@ -203,8 +203,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const audioContext = new (window.AudioContext ||
     window.webkitAudioContext)();
   let audioBuffer = null;
-  let isPlaying = false;
-  let playheadReqId = null;
   let zoomLevel = 1;
   let panOffset = 0;
 
@@ -218,7 +216,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const waveformContainer = document.getElementById("waveformContainer");
   const waveformCanvas = document.getElementById("waveformCanvas");
   const canvasCtx = waveformCanvas.getContext("2d");
-  const playheadDiv = document.getElementById("playhead");
 
   function formatTime(t) {
     const totalMs = Math.floor(t * 1000);
@@ -598,10 +595,6 @@ document.addEventListener("DOMContentLoaded", () => {
   let captionsEnabled = true;
 
   const fullscreenBtn = document.getElementById("fullscreen-btn");
-  const timelineContainer = document.getElementById("timelineContainer");
-  const timelineCanvas = document.getElementById("timelineCanvas");
-  const timelineCtx = timelineCanvas.getContext("2d");
-  let timelineEnabled = false;
 
   document.addEventListener("keydown", (e) => {
     if (e.code === "Enter") {
@@ -666,7 +659,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  timelineCanvas.style.display = "none";
 
   const fileInput = document.getElementById("fileInput");
   const videoContainer = document.getElementById("video-container");
@@ -772,7 +764,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (!isNaN(newTime)) {
       video.currentTime = newTime;
-      drawTimeline();
       updateTimeDisplay();
 
       video.play();
@@ -798,8 +789,6 @@ document.addEventListener("DOMContentLoaded", () => {
     video.addEventListener(
       "loadedmetadata",
       () => {
-        playheadDiv.style.display = "block";
-        playheadDiv.style.left = "0px";
         if (audioBuffer) {
           drawWaveform();
         }
@@ -816,10 +805,6 @@ document.addEventListener("DOMContentLoaded", () => {
     baselineHeight = videoContainer.clientHeight;
     baselineOverlayBottom = baselineHeight * 0.05;
 
-    timelineCanvas.style.display = "block";
-    timelineEnabled = true;
-    resizeTimelineCanvas();
-    drawTimeline();
     videoContainer.style.borderColor = "transparent";
     copyBtn.disabled = false;
 
@@ -847,37 +832,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (video.readyState >= 1) {
           waveformContainer.style.visibility = "visible";
-          playheadDiv.style.visibility = "visible";
-
           drawWaveform();
-
-          updateZoomHighlight();
         }
       })
       .catch((err) => {
         audioBuffer = null;
         drawWaveform();
-
-        updateZoomHighlight();
       });
   }
 
   video.addEventListener("timeupdate", () => {
     if (!isNaN(video.duration)) {
-      drawTimeline();
       updateTimeDisplay();
     }
-
-    if (!isSeeking && audioBuffer) {
-      updatePlayhead();
-    }
   });
 
-  video.addEventListener("play", () => {
-    if (audioBuffer) {
-      updatePlayhead();
-    }
-  });
+  // Removed timeline playhead update on play
 
   function updateSamiOverlay(now, metadata) {
     const t = metadata.mediaTime;
@@ -911,59 +881,14 @@ document.addEventListener("DOMContentLoaded", () => {
     video.requestVideoFrameCallback(updateSamiOverlay);
   });
 
-  video.addEventListener("pause", () => {
-    cancelAnimationFrame(playheadReqId);
-  });
-
   let isScrubbing = false;
-  let isTimelineScrubbing = false;
   let scrubTimeout;
 
   let wasScrubbing = false;
   let didDrag = false;
   let dragStartX = 0;
 
-  function seekTimelineCanvas(e) {
-    const rect = timelineCanvas.getBoundingClientRect();
-    let x = e.clientX - rect.left;
-    x = Math.max(0, Math.min(x, rect.width));
-    const newTime = (x / rect.width) * video.duration;
-    if (!isNaN(newTime)) {
-      video.currentTime = newTime;
-      drawTimeline();
-      updatePlayhead();
-      video.play();
-      clearTimeout(scrubTimeout);
-      scrubTimeout = setTimeout(() => {
-        video.pause();
-      }, 100);
-    }
-  }
-
-  timelineCanvas.addEventListener("pointerdown", (e) => {
-    if (!video.src) return;
-    isTimelineScrubbing = true;
-    video.pause();
-    seekTimelineCanvas(e);
-  });
-
-  timelineCanvas.addEventListener("pointermove", (e) => {
-    if (!isTimelineScrubbing || isNaN(video.duration)) return;
-    seekTimelineCanvas(e);
-  });
-
-  window.addEventListener("pointerup", () => {
-    if (!isTimelineScrubbing) return;
-    isTimelineScrubbing = false;
-    clearTimeout(scrubTimeout);
-    video.pause();
-  });
-
-  video.addEventListener("loadedmetadata", () => {
-    timeDisplay.disabled = false;
-    resizeTimelineCanvas();
-    drawTimeline();
-  });
+  // Removed timeline canvas seeking functionality
 
   timeDisplay.addEventListener("click", (e) => {
     e.preventDefault();
@@ -983,8 +908,6 @@ document.addEventListener("DOMContentLoaded", () => {
     if (t != null && !isNaN(video.duration)) {
       video.currentTime = Math.min(t, video.duration);
 
-      drawTimeline();
-      updatePlayhead();
       video.play();
       clearTimeout(scrubTimeout);
       scrubTimeout = setTimeout(() => {
@@ -1020,14 +943,10 @@ document.addEventListener("DOMContentLoaded", () => {
       fullscreenBtn.disabled = true;
 
       timeDisplay.value = "00:00.000";
-      timelineEnabled = false;
-      timelineCanvas.style.display = "none";
-      drawTimeline();
 
       fileInput.value = "";
 
       waveformContainer.style.visibility = "hidden";
-      playheadDiv.style.display = "none";
     }
   });
 
@@ -1046,33 +965,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
   window.addEventListener("resize", updateOutputBounds);
 
-  function updateZoomHighlight() {
-    if (!audioBuffer || isNaN(video.duration)) {
-      document.getElementById("zoomHighlight").style.width = "0";
-      return;
-    }
-
-    const totalSamples = audioBuffer.length;
-    const duration = video.duration;
-
-    const segmentLength = Math.floor(totalSamples / zoomLevel);
-    const startSample = Math.floor(panOffset);
-    const endSample = startSample + segmentLength;
-
-    const startTime = (startSample / totalSamples) * duration;
-    const endTime = Math.min(
-      (endSample / totalSamples) * duration,
-      duration
-    );
-
-    const startPct = (startTime / duration) * 100;
-    const widthPct = ((endTime - startTime) / duration) * 100;
-
-    const highlight = document.getElementById("zoomHighlight");
-    highlight.style.left = `${startPct}%`;
-    highlight.style.width = `${widthPct}%`;
-  }
-
   function resizeWaveformCanvas() {
     const rect = waveformContainer.getBoundingClientRect();
     waveformCanvas.width = rect.width;
@@ -1080,28 +972,8 @@ document.addEventListener("DOMContentLoaded", () => {
     drawWaveform();
   }
 
-  function resizeTimelineCanvas() {
-    const rect = timelineContainer.getBoundingClientRect();
-    timelineCanvas.width = rect.width;
-    timelineCanvas.height = rect.height;
-    drawTimeline();
-  }
-
-  function drawTimeline() {
-    const width = timelineCanvas.width;
-    const height = timelineCanvas.height;
-    timelineCtx.clearRect(0, 0, width, height);
-    if (!timelineEnabled || isNaN(video.duration) || video.duration === 0)
-      return;
-    // The red playhead is now rendered via the CSS #playhead element.
-  }
-
   window.addEventListener("resize", resizeWaveformCanvas);
-  window.addEventListener("resize", resizeTimelineCanvas);
   resizeWaveformCanvas();
-  resizeTimelineCanvas();
-
-  updateZoomHighlight();
 
   let controlTimeout;
   const player = document.getElementById("player-container");
@@ -2206,27 +2078,7 @@ ${styleLines}
 
       panOffset = desiredPan;
       drawWaveform();
-      updateZoomHighlight();
 
-      const phW = playheadDiv.offsetWidth;
-      const visW = timelineContainer.clientWidth;
-
-      let relX;
-      if (segmentLength >= totalSamples) {
-        relX = currentSample / totalSamples;
-      } else if (
-        panOffsetTarget > 0 &&
-        panOffsetTarget < totalSamples - segmentLength
-      ) {
-        relX = 0.5;
-      } else {
-        relX = (currentSample - panOffset) / segmentLength;
-      }
-
-      let cssX = relX * (visW - phW);
-
-      cssX = Math.max(0, Math.min(visW - phW, cssX));
-      playheadDiv.style.left = cssX + "px";
     }
   });
 
@@ -2638,73 +2490,6 @@ ${styleLines}
     }
   }
 
-  function updatePlayhead() {
-    if (video.paused || isSeeking) {
-      cancelAnimationFrame(playheadReqId);
-      return;
-    }
-
-    const currentTime = video.currentTime;
-    const duration = video.duration;
-    const totalSamples = audioBuffer ? audioBuffer.length : 0;
-    const currentSample =
-      duration > 0 ? (currentTime / duration) * totalSamples : 0;
-
-    const segmentLength = Math.floor(totalSamples / zoomLevel);
-
-    let desiredPan;
-    if (segmentLength >= totalSamples) {
-      desiredPan = 0;
-    } else {
-      desiredPan = currentSample - segmentLength / 2;
-    }
-
-    if (desiredPan < 0) desiredPan = 0;
-    if (desiredPan > totalSamples - segmentLength) {
-      desiredPan = totalSamples - segmentLength;
-    }
-
-    panOffsetTarget = desiredPan;
-
-    panOffset += (panOffsetTarget - panOffset) * panSmooth;
-
-    if (Math.abs(panOffset - panOffsetTarget) < 0.5) {
-      panOffset = panOffsetTarget;
-    }
-
-    drawWaveform();
-    updateZoomHighlight();
-
-    let xPos;
-    if (segmentLength >= totalSamples) {
-      xPos = (currentSample / totalSamples) * waveformCanvas.width;
-    } else {
-      if (
-        panOffsetTarget > 0 &&
-        panOffsetTarget < totalSamples - segmentLength
-      ) {
-        xPos = waveformCanvas.width / 2;
-      } else {
-        xPos =
-          ((currentSample - panOffset) / segmentLength) *
-          waveformCanvas.width;
-      }
-    }
-
-    const timelineW = timelineContainer.getBoundingClientRect().width;
-    const internalW = waveformCanvas.width;
-
-    const phW = playheadDiv.offsetWidth;
-    const scaleFactor = (timelineW - phW) / internalW;
-
-    let cssX = xPos * scaleFactor;
-
-    cssX = Math.max(0, Math.min(timelineW - phW, cssX));
-    playheadDiv.style.left = cssX + "px";
-
-    playheadReqId = requestAnimationFrame(updatePlayhead);
-  }
-
   let singleFrameTimeout;
 
   waveformCanvas.addEventListener("mousedown", (e) => {
@@ -2757,7 +2542,6 @@ ${styleLines}
             )
           );
           drawWaveform();
-          updateZoomHighlight();
         }, SCROLL_INTERVAL_MS);
       }
     }
@@ -2807,20 +2591,9 @@ ${styleLines}
     panOffset = newPan;
 
     drawWaveform();
-    updateZoomHighlight();
-
-    const phW = playheadDiv.offsetWidth;
-    const visW = timelineContainer.clientWidth;
-    const relX = (targetSample - panOffset) / segmentLength;
-
-    let cssX = relX * (visW - phW);
-
-    cssX = Math.max(0, Math.min(visW - phW, cssX));
-    playheadDiv.style.left = cssX + "px";
 
     const newTime = (targetSample / totalSamples) * video.duration;
     video.currentTime = newTime;
-    drawTimeline();
     updateTimeDisplay();
   }
 
@@ -2829,10 +2602,9 @@ ${styleLines}
     e.preventDefault();
 
     const totalSamples = audioBuffer.length;
-    const width = timelineContainer.clientWidth;
+    const width = waveformCanvas.width;
 
-    const playheadStyleLeft = parseFloat(playheadDiv.style.left) || 0;
-    const headRatio = playheadStyleLeft / width;
+    const headRatio = 0.5;
 
     const zoomFactor = 1.2;
     let newZoom =
@@ -2851,13 +2623,6 @@ ${styleLines}
     panOffset = newPan;
 
     drawWaveform();
-
-    updateZoomHighlight();
-
-    if (!video.paused) {
-      cancelAnimationFrame(playheadReqId);
-      updatePlayhead();
-    }
   });
 
   document.body.addEventListener("dragstart", (e) => {

--- a/styles.css
+++ b/styles.css
@@ -604,23 +604,6 @@ button:disabled:hover {
   pointer-events: none;
 }
 
-#player-container:-webkit-full-screen #timelineContainer,
-#player-container:fullscreen #timelineContainer {
-  position: absolute !important;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 28px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-
-#player-container:-webkit-full-screen.show-controls #timelineContainer,
-#player-container:fullscreen.show-controls #timelineContainer {
-  opacity: 1;
-  pointer-events: auto;
-}
 
 #player-container:fullscreen #copy-btn,
 #player-container:-webkit-full-screen #copy-btn {
@@ -690,19 +673,6 @@ button:disabled:hover {
   color: #6b7280;
   font-size: 15px;
   pointer-events: none;
-}
-
-.video-panel #timelineCanvas {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 28px;
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  cursor: pointer;
-  z-index: 3;
 }
 
 .video-panel .controls {
@@ -1466,17 +1436,6 @@ body.modal-open * {
   cursor: grabbing;
 }
 
-#playhead {
-  position: absolute;
-  top: 0;
-  width: 4px;
-  height: calc(100% + 104px);
-  background-color: rgba(255, 0, 0, 0.8);
-  pointer-events: none;
-  display: none;
-  z-index: 3;
-}
-
 #samiOverlay {
   position: absolute;
   bottom: 5%;
@@ -1491,33 +1450,6 @@ body.modal-open * {
   will-change: transform, opacity;
 }
 
-#timelineContainer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 28px;
-  position: relative;
-  background-color: #f9fafb;
-  box-sizing: border-box;
-}
-
-#zoomHighlight {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  height: 28px;
-  background-color: #4285f4;
-  pointer-events: none;
-  z-index: 2;
-  left: 0;
-  width: 0;
-}
-
-#player-container:-webkit-full-screen #zoomHighlight,
-#player-container:fullscreen #zoomHighlight {
-  display: none !important;
-}
 
 #leftBar {
   position: fixed;


### PR DESCRIPTION
## Summary
- strip out timeline container and its child elements from the markup
- drop timeline-related styles including playhead and zoom highlight
- clean JavaScript by removing timeline logic and playhead updates

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c20dd00488332b2cb6e4f84816510