### PR TITLE
Add playhead overlays for timeline and waveform

### DIFF
--- a/script.js
+++ b/script.js
@@ -219,6 +219,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const waveformCanvas = document.getElementById("waveformCanvas");
   const canvasCtx = waveformCanvas.getContext("2d");
   const playheadDiv = document.getElementById("playhead");
+  const waveformPlayheadDiv = document.getElementById("waveformPlayhead");
 
 
   function formatTime(t) {
@@ -800,6 +801,7 @@ document.addEventListener("DOMContentLoaded", () => {
       "loadedmetadata",
       () => {
         playheadDiv.style.display = "block";
+        waveformPlayheadDiv.style.display = "block";
 
         if (audioBuffer) {
           drawWaveform();
@@ -849,6 +851,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (video.readyState >= 1) {
           waveformContainer.style.visibility = "visible";
           playheadDiv.style.visibility = "visible";
+          waveformPlayheadDiv.style.visibility = "visible";
 
 
           drawWaveform();
@@ -1030,6 +1033,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       waveformContainer.style.visibility = "hidden";
       playheadDiv.style.display = "none";
+      waveformPlayheadDiv.style.display = "none";
 
     }
   });
@@ -2230,6 +2234,7 @@ ${styleLines}
 
       cssX = Math.max(0, Math.min(visW - phW, cssX));
       playheadDiv.style.left = cssX + "px";
+      waveformPlayheadDiv.style.left = cssX + "px";
 
     }
   });
@@ -2705,6 +2710,7 @@ ${styleLines}
 
     cssX = Math.max(0, Math.min(timelineW - phW, cssX));
     playheadDiv.style.left = cssX + "px";
+    waveformPlayheadDiv.style.left = cssX + "px";
 
 
     playheadReqId = requestAnimationFrame(updatePlayhead);
@@ -2822,6 +2828,7 @@ ${styleLines}
 
     cssX = Math.max(0, Math.min(visW - phW, cssX));
     playheadDiv.style.left = cssX + "px";
+    waveformPlayheadDiv.style.left = cssX + "px";
 
 
     const newTime = (targetSample / totalSamples) * video.duration;

--- a/styles.css
+++ b/styles.css
@@ -1708,3 +1708,15 @@ body.modal-open * {
 #copy-btn.active .material-icons {
   color: #4285f4;
 }
+
+#playhead,
+#waveformPlayhead {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  background-color: #ff0000;
+  pointer-events: none;
+  display: none;
+  z-index: 3;
+}


### PR DESCRIPTION
## Summary
- show playhead elements for both timeline and waveform canvases
- synchronize waveform playhead with timeline position
- style playheads as visible red lines on the canvas overlays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5cb282288332b3c051e4bbb5b899